### PR TITLE
Lumen Application class and Application contract

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -2,8 +2,10 @@
 
 namespace Nuwber\Events;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Application as LaravelApplication;
+use Laravel\Lumen\Application as LumenApplication;
 use Interop\Amqp\AmqpConsumer;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
 
@@ -18,21 +20,23 @@ class Worker
 
     /** @var AmqpConsumer */
     private $consumer;
+
     /**
-     * @var Application
+     * @var LaravelApplication|LumenApplication
      */
     private $app;
+
     /**
      * @var MessageProcessor
      */
     private $processor;
 
     /**
-     * @param Application $app
+     * @param LaravelApplication|LumenApplication $app
      * @param AmqpConsumer $consumer
      * @param MessageProcessor $processor
      */
-    public function __construct($app, AmqpConsumer $consumer, MessageProcessor $processor)
+    public function __construct(Container $app, AmqpConsumer $consumer, MessageProcessor $processor)
     {
         $this->app = $app;
         $this->consumer = $consumer;

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -27,7 +27,12 @@ class Worker
      */
     private $processor;
 
-    public function __construct(Application $app, AmqpConsumer $consumer, MessageProcessor $processor)
+    /**
+     * @param Application $app
+     * @param AmqpConsumer $consumer
+     * @param MessageProcessor $processor
+     */
+    public function __construct($app, AmqpConsumer $consumer, MessageProcessor $processor)
     {
         $this->app = $app;
         $this->consumer = $consumer;


### PR DESCRIPTION
Lumen Application class does't implement  `Contracts\Foundation\Application`.

```
Argument 1 passed to Nuwber\Events\Worker::__construct() must be an instance of Illuminate\Contracts\Foundation\Application, instance of Laravel\Lumen\Application given, called in vendor/nuwber/rabbitevents/src/Console/ListenCommand.php on line 84
```