### PR TITLE
Laravel 5.8 hasn't class FailingJob

### DIFF
--- a/src/MessageProcessor.php
+++ b/src/MessageProcessor.php
@@ -3,14 +3,12 @@
 namespace Nuwber\Events;
 
 use Exception;
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Queue\FailingJob;
 use Illuminate\Queue\MaxAttemptsExceededException;
 use Interop\Amqp\AmqpMessage;
 use Nuwber\Events\Exceptions\FailedException;
@@ -22,19 +20,19 @@ class MessageProcessor
     /**
      * @var Dispatcher
      */
-    private $events;
+    protected $events;
     /**
      * @var ProcessingOptions
      */
-    private $options;
+    protected $options;
     /**
      * @var JobsFactory
      */
-    private $jobsFactory;
+    protected $jobsFactory;
     /**
      * @var ExceptionHandler
      */
-    private $exceptions;
+    protected $exceptions;
 
     public function __construct(
         Dispatcher $events,
@@ -132,7 +130,12 @@ class MessageProcessor
      */
     protected function failJob(Job $job, $e)
     {
-        FailingJob::handle($this->options->connectionName, $job, $e);
+        //Added this to support Laravel version < 5.8
+        if (class_exists('Illuminate\Queue\FailingJob')) {
+            \Illuminate\Queue\FailingJob::handle($this->options->connectionName, $job, $e);
+        } else {
+            $job->fail($e);
+        }
     }
 
     /**

--- a/tests/MessageProcessorTest.php
+++ b/tests/MessageProcessorTest.php
@@ -2,7 +2,6 @@
 
 namespace Nuwber\Events\Tests;
 
-use Enqueue\AmqpLib\AmqpProducer;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Events\Dispatcher as Events;
@@ -12,7 +11,6 @@ use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Interop\Amqp\Impl\AmqpMessage;
-use Interop\Queue\PsrContext;
 use Mockery as m;
 use Nuwber\Events\Exceptions\FailedException;
 use Nuwber\Events\Job;
@@ -248,5 +246,10 @@ class FakeJob extends Job
     public function setConnectionName($name)
     {
         $this->connectionName = $name;
+    }
+
+    public function resolve($class)
+    {
+        return Container::getInstance()->make($class);
     }
 }


### PR DESCRIPTION
There's exception in last tests 
```
2) Nuwber\Events\Tests\MessageProcessorTest::testRunJobFailed
Failed asserting that exception message 'Class 'Illuminate\Queue\FailingJob' not found' contains 'Failed job exception'.
```
this is because in Laravel 5.8 they made the following change 
```
When a queued job failed in Laravel 5.7, the queue worker executed the FailingJob::handle method. In Laravel 5.8, the logic contained in the FailingJob class has been moved to a fail method directly on the job class itself. Because of this, a fail method has been added to the  Illuminate\Contracts\Queue\Job contract.
```

So now it should work.

Here I'm also made changes suggested here https://github.com/nuwber/rabbitevents/pull/25. I've copied it to be sure that the reason ton in changes and so lazy to turn it back.