### PR TITLE
Laravel 8 Job timeoutAt fix

### DIFF
--- a/src/Queue/Job.php
+++ b/src/Queue/Job.php
@@ -126,4 +126,14 @@ class Job extends \Illuminate\Queue\Jobs\Job
     {
         return $this->getName();
     }
+    
+    /**
+     * Get the timestamp indicating when the job should timeout.
+     *
+     * @return int|null
+     */
+    public function timeoutAt()
+    {
+        return $this->payload()['timeoutAt'] ?? null;
+    }
 }


### PR DESCRIPTION
timeoutAt has been removed in Laravel 8 from the Job class

https://github.com/laravel/framework/blob/8.x/src/Illuminate/Queue/Jobs/Job.php

Just adding it back on this Job.php to make things work properly with Laravel 8