### PR TITLE
Fix ack of acknowledged messages

### DIFF
--- a/src/Queue/Jobs/Job.php
+++ b/src/Queue/Jobs/Job.php
@@ -121,9 +121,4 @@ class Job extends \Illuminate\Queue\Jobs\Job implements \Illuminate\Contracts\Qu
     {
         return $this->payload()['timeoutAt'] ?? null;
     }
-
-    public function __destruct()
-    {
-        $this->queueManager->acknowledge($this->message);
-    }
 }

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -44,6 +44,8 @@ class Worker
             try {
                 if ($message = $queue->nextMessage($options->timeout)) {
                     $processor->process($message, $options);
+
+                    $queue->acknowledge($message);
                 }
             } catch (Throwable $throwable) {
                 $this->exceptions->report($throwable);

--- a/tests/Queue/Jobs/JobTest.php
+++ b/tests/Queue/Jobs/JobTest.php
@@ -145,24 +145,6 @@ class JobTest extends TestCase
         self::assertEquals("test-app:{$this->event}", $job->getQueue());
     }
 
-    public function testDestructor()
-    {
-        $manager = new FakeManager();
-        $job = new Job(
-            m::mock(Container::class),
-            $manager,
-            $this->getMessage(),
-            'trim',
-            $this->listenerClass
-        );
-
-        self::assertFalse($manager->acknowledged);
-
-        unset($job);
-
-        self::assertTrue($manager->acknowledged);
-    }
-
     protected function getMessage(): AmqpMessage
     {
         $message = new \Interop\Amqp\Impl\AmqpMessage('{"id": 1}',);


### PR DESCRIPTION
There're errors:

Message: PRECONDITION_FAILED - unknown delivery tag 1

and

Message: Channel connection is closed.

It could happen if you have many listeners. First listener acknowledges a message and when the last one tries to do same we're getting these error messages. 

I've turned  acknowledge back in place where it was before refactoring