### PR TITLE
Fix : No acknowlege when an exception occured 

### DIFF
--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -51,7 +51,8 @@ class Worker
                 $this->stopListeningIfLostConnection($throwable);
             }
             finally {
-            $queue->acknowledge($message);
+                if(isset($message))
+                    $queue->acknowledge($message);
             }
             
             $this->stopIfNecessary($options);

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -44,14 +44,16 @@ class Worker
             try {
                 if ($message = $queue->nextMessage($options->timeout)) {
                     $processor->process($message, $options);
-
-                    $queue->acknowledge($message);
                 }
             } catch (Throwable $throwable) {
                 $this->exceptions->report($throwable);
 
                 $this->stopListeningIfLostConnection($throwable);
             }
+            finally {
+            $queue->acknowledge($message);
+            }
+            
             $this->stopIfNecessary($options);
         }
     }


### PR DESCRIPTION
It seem that no acknowledge would be send if an exception occurred during the working process. This making the message blocked in "unacked" status.