### PR TITLE
Allow "passive" declaration of Exchange and Queue

### DIFF
--- a/config/rabbitevents.php
+++ b/config/rabbitevents.php
@@ -20,6 +20,9 @@ return [
         'rabbitmq' => [
             'driver' => 'rabbitmq',
             'exchange' => env('RABBITEVENTS_EXCHANGE', 'events'),
+            'queue' => env('RABBITEVENTS_QUEUE', null),
+            'exchange_passive' => env('RABBITEVENTS_EXCHANGE_PASSIVE', false),
+            'queue_passive' => env('RABBITEVENTS_QUEUE_PASSIVE', false),
             'host' => env('RABBITEVENTS_HOST', 'localhost'),
             'port' => env('RABBITEVENTS_PORT', 5672),
             'user' => env('RABBITEVENTS_USER', 'guest'),

--- a/src/Amqp/Connection.php
+++ b/src/Amqp/Connection.php
@@ -56,7 +56,10 @@ class Connection
 
     protected function makeTopic(AmqpContext $context): Topic
     {
-        return (new TopicFactory($context))->make($this->config->get('exchange'));
+        return (new TopicFactory($context))->make(
+            $this->config->get('exchange'),
+            $this->config->get('exchange_passive')
+        );
     }
 
     /**

--- a/src/Amqp/TopicFactory.php
+++ b/src/Amqp/TopicFactory.php
@@ -20,11 +20,15 @@ class TopicFactory
         $this->context = $context;
     }
 
-    public function make(?string $exchange = ''): Topic
+    public function make(?string $exchange = '', bool $passive = false): Topic
     {
         $topic = $this->context->createTopic($exchange ?: self::DEFAULT_EXCHANGE_NAME);
         $topic->setType(AmqpTopic::TYPE_TOPIC);
         $topic->addFlag(AmqpTopic::FLAG_DURABLE);
+        
+        if($passive) {
+            $topic->addFlag(AmqpTopic::FLAG_PASSIVE);
+        }
 
         $this->context->declareTopic($topic);
 

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -27,7 +27,7 @@ class ListenCommand extends Command
      */
     protected $signature = 'rabbitevents:listen
                             {event : The name of the event to listen to}
-                            {--service= : The name of current service. Necessary to identify listeners}
+                            {--service= : The name of current service. Necessary to identify listeners. Defaults to config(\'app.name\').}
                             {--connection= : The name of the queue connection to work}
                             {--memory=128 : The memory limit in megabytes}
                             {--timeout=60 : The number of seconds a child process can run}
@@ -138,6 +138,8 @@ class ListenCommand extends Command
             $options->service
         );
 
-        return $factory->make($this->argument('event'));
+        $config = $this->laravel['config']->get('rabbitevents.connections.' . $options->connectionName);
+        return $factory->make($this->argument('event'), $config['queue'] ?? null, $config['queue_passive'] ?? null);
     }
 }
+

--- a/tests/Amqp/ConnectionPassiveTest.php
+++ b/tests/Amqp/ConnectionPassiveTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Nuwber\Events\Tests\Amqp;
+
+use Enqueue\AmqpTools\DelayStrategy;
+use Interop\Amqp\AmqpConnectionFactory;
+use Nuwber\Events\Amqp\Connection;
+use Nuwber\Events\Queue\Context;
+use Nuwber\Events\Tests\TestCase;
+
+class ConnectionPassiveTest extends TestCase
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = new Connection([
+            'exchange' => 'custom',
+            'exchange_passive' => true
+        ]);
+    }
+
+    public function testConnect()
+    {
+        self::assertInstanceOf(AmqpConnectionFactory::class, $this->connection->connect());
+    }
+
+}

--- a/tests/Amqp/QueueFactoryTest.php
+++ b/tests/Amqp/QueueFactoryTest.php
@@ -49,4 +49,72 @@ class QueueFactoryTest extends TestCase
         self::assertSame($amqpQueue, $queue);
         self::assertEquals($queueName, $queue->getQueueName());
     }
+
+    public function testMakePassive()
+    {
+        $queueName = "test-app:{$this->event}";
+
+        $amqpQueue = new ImplAmqpQueue($queueName);
+        $amqpTopic = \Mockery::spy(AmqpTopic::class);
+
+        $context = \Mockery::mock(Context::class, [\Mockery::mock(AmqpContext::class), $amqpTopic])->makePartial();
+        $context->shouldReceive()
+            ->createQueue($queueName)
+            ->andReturn($amqpQueue);
+
+        $context->shouldReceive()->declareQueue($amqpQueue);
+
+        $context->shouldReceive('topic')
+            ->andReturn($amqpTopic);
+
+        $amqpBind = new AmqpBind($amqpTopic, $amqpQueue, $this->event);
+        $bind = \Mockery::mock(BindFactory::class, [$context])->makePartial();
+        $bind->shouldReceive()->make($amqpQueue, $this->event)
+            ->andReturn($amqpBind);
+
+        $context->shouldReceive()->bind($amqpBind);
+
+        $factory = new QueueFactory($context, $bind, 'test-app');
+
+        $queue = $factory->make($this->event, null, true);
+
+        self::assertInstanceOf(AmqpQueue::class, $queue);
+        self::assertEquals(AmqpQueue::FLAG_DURABLE | AmqpQueue::FLAG_PASSIVE, $queue->getFlags());
+        self::assertSame($amqpQueue, $queue);
+        self::assertEquals($queueName, $queue->getQueueName());
+    }
+
+    public function testMakeWithCustomQueueName()
+    {
+        $customQueueName = 'customQueueName';
+
+        $amqpQueue = new ImplAmqpQueue($customQueueName);
+        $amqpTopic = \Mockery::spy(AmqpTopic::class);
+
+        $context = \Mockery::mock(Context::class, [\Mockery::mock(AmqpContext::class), $amqpTopic])->makePartial();
+        $context->shouldReceive()
+            ->createQueue($customQueueName)
+            ->andReturn($amqpQueue);
+
+        $context->shouldReceive()->declareQueue($amqpQueue);
+
+        $context->shouldReceive('topic')
+            ->andReturn($amqpTopic);
+
+        $amqpBind = new AmqpBind($amqpTopic, $amqpQueue, $this->event);
+        $bind = \Mockery::mock(BindFactory::class, [$context])->makePartial();
+        $bind->shouldReceive()->make($amqpQueue, $this->event)
+            ->andReturn($amqpBind);
+
+        $context->shouldReceive()->bind($amqpBind);
+
+        $factory = new QueueFactory($context, $bind, 'test-app');
+
+        $queue = $factory->make($this->event, $customQueueName, false);
+
+        self::assertInstanceOf(AmqpQueue::class, $queue);
+        self::assertEquals(AmqpQueue::FLAG_DURABLE, $queue->getFlags());
+        self::assertSame($amqpQueue, $queue);
+        self::assertEquals($customQueueName, $queue->getQueueName());
+    }
 }

--- a/tests/Amqp/TopicFactoryTest.php
+++ b/tests/Amqp/TopicFactoryTest.php
@@ -28,4 +28,22 @@ class TopicFactoryTest extends TestCase
         self::assertEquals(AmqpTopic::TYPE_TOPIC, $topic->getType());
         self::assertEquals(AmqpTopic::FLAG_DURABLE, $topic->getFlags());
     }
+
+    public function testMakePassive()
+    {
+        $exchange = 'events';
+
+        $context = \Mockery::mock(AmqpContext::class);
+        $context->shouldReceive('createTopic')
+            ->andReturn($amqpTopic = new ImplAmqpTopic($exchange));
+        $context->shouldReceive()
+            ->declareTopic($amqpTopic);
+
+        $factory = new TopicFactory($context);
+        $topic = $factory->make($exchange, true);
+
+        self::assertSame($amqpTopic, $topic);
+        self::assertEquals(AmqpTopic::TYPE_TOPIC, $topic->getType());
+        self::assertEquals(AmqpTopic::FLAG_DURABLE | AmqpTopic::FLAG_PASSIVE, $topic->getFlags());
+    }
 }


### PR DESCRIPTION
In a microservice architecture, a Publisher and its Listenner(s) are supposed to be decoupled. In particular, Listeners should not have any configuration permission on the Exchange.

This PR adds support for two new environment variables (and their corresponding config parameters). If set to true (false by default), these configs will make the library "declare" the queues in passive mode (i.e. expect the exchange or queue to already exist).

`RABBITEVENTS_EXCHANGE_PASSIVE`
`RABBITEVENTS_QUEUE_PASSIVE`

Additionally, the PR introduces the `RABBITEVENTS_QUEUE` envvar that matches the existing `RABBITEVENTS_EXCHANGE` envvar. It allows the listenner to define a static name for the queue, independently of the event watched. This permits reducing the number of queues created (i.e. one single queue may be used to listen to multiple events one queue per listener per event). As a nice side effect, it also allows defining an arbitrary name for the queue to comply with an existing naming policy in place in the organisation.

