### PR TITLE
Allow closure listeners

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,8 @@ The `listen` property of `RabbitEventsServiceProvider` contains an array of all 
 protected $listen = [
     'item.created' => [
         'App\Listeners\SendItemCreatedNotification',
-        'App\Listeners\ChangeUserRole',
+        'App\Listeners\ChangeUserRole@process',
+        function($payload) { Log::info('Item created', $payload); },
     ],
 ];
 ```

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -29,9 +29,7 @@ class Dispatcher extends BaseDispatcher
             if (Str::contains($event, '*')) {
                 $this->setupWildcardListen($event, $listener);
             } else {
-                $this->listeners[$event][$this->getListenerClass($listener)][] = !$listener instanceof \Closure
-                    ? $this->makeListener($listener)
-                    : $listener;
+                $this->listeners[$event][$this->getListenerClass($listener)][] = $this->makeListener($listener);
             }
         }
     }
@@ -41,6 +39,10 @@ class Dispatcher extends BaseDispatcher
      */
     public function makeListener($listener, $wildcard = false): \Closure
     {
+        if ($listener instanceof \Closure) {
+            return $listener;
+        }
+
         return function ($event, $payload) use ($listener, $wildcard) {
             $throughMiddleware = $this->extractMiddleware($listener);
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -89,6 +89,10 @@ class Dispatcher extends BaseDispatcher
             return $this->container->instance($class, $this->container->make($class));
         }
 
+        if ($listener instanceof \Closure) {
+            return null;
+        }
+
         if (is_object($listener)) {
             return $listener;
         }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -29,7 +29,9 @@ class Dispatcher extends BaseDispatcher
             if (Str::contains($event, '*')) {
                 $this->setupWildcardListen($event, $listener);
             } else {
-                $this->listeners[$event][$this->getListenerClass($listener)][] = $this->makeListener($listener);
+                $this->listeners[$event][$this->getListenerClass($listener)][] = !$listener instanceof \Closure
+                    ? $this->makeListener($listener)
+                    : $listener;
             }
         }
     }
@@ -87,10 +89,6 @@ class Dispatcher extends BaseDispatcher
             list($class,) = Str::parseCallback($listener);
 
             return $this->container->instance($class, $this->container->make($class));
-        }
-
-        if ($listener instanceof \Closure) {
-            return null;
         }
 
         if (is_object($listener)) {

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -50,6 +50,8 @@ class DispatcherTest extends TestCase
         self::assertEquals(['Closure'], array_keys($listeners));
 
         self::assertCount(2, $listeners['Closure']);
+
+        $dispatcher->makeListener(static function() {})(':event:', []);
     }
 
     public function testCorrectWildcardHandling()

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -39,9 +39,11 @@ class DispatcherTest extends TestCase
     public function testAddedClosureListeners()
     {
         $dispatcher = new Dispatcher();
+        $closure1 = function() {};
+        $closure2 = function() {};
 
-        $dispatcher->listen('item.event', function() {});
-        $dispatcher->listen('item.event', function() {});
+        $dispatcher->listen('item.event', $closure1);
+        $dispatcher->listen('item.event', $closure2);
 
         $listeners = $dispatcher->getListeners('item.event');
 
@@ -51,7 +53,9 @@ class DispatcherTest extends TestCase
 
         self::assertCount(2, $listeners['Closure']);
 
-        $dispatcher->makeListener(static function() {})(':event:', []);
+        self::assertSame($closure1, $listeners['Closure'][0]);
+
+        self::assertSame($closure2, $listeners['Closure'][1]);
     }
 
     public function testCorrectWildcardHandling()


### PR DESCRIPTION
Currently the closure listeners are not allowed because they are objects but they don't allow middlewares, so the library crashes. If we add a detection when trying to discover the middlewares it works like a charm.