### PR TITLE
No message if worker has been killed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     }
   },
   "suggest": {
+    "ext-pcntl": "Required to use all features of the worker.",
     "vlucas/phpdotenv": "Loads environment variables from .env to getenv(), $_ENV and $_SERVER automagically."
   },
   "config": {

--- a/src/RabbitEvents/Listener/Commands/ListenCommand.php
+++ b/src/RabbitEvents/Listener/Commands/ListenCommand.php
@@ -13,6 +13,7 @@ use RabbitEvents\Listener\Events\ListenerHandleFailed;
 use RabbitEvents\Listener\Events\ListenerHandled;
 use RabbitEvents\Listener\Events\ListenerHandling;
 use RabbitEvents\Listener\Events\MessageProcessingFailed;
+use RabbitEvents\Listener\Events\WorkerStopping;
 use RabbitEvents\Listener\Message\HandlerFactory;
 use RabbitEvents\Listener\Message\Processor;
 use RabbitEvents\Listener\Message\ProcessingOptions;
@@ -107,6 +108,7 @@ class ListenCommand extends Command
         $this->laravel['events']->listen(ListenerHandleFailed::class, $callback);
         $this->laravel['events']->listen(ListenerHandlerExceptionOccurred::class, $callback);
         $this->laravel['events']->listen(MessageProcessingFailed::class, $callback);
+        $this->laravel['events']->listen(WorkerStopping::class, $callback);
     }
 
     /**

--- a/src/RabbitEvents/Listener/Commands/ListenCommand.php
+++ b/src/RabbitEvents/Listener/Commands/ListenCommand.php
@@ -108,7 +108,9 @@ class ListenCommand extends Command
         $this->laravel['events']->listen(ListenerHandleFailed::class, $callback);
         $this->laravel['events']->listen(ListenerHandlerExceptionOccurred::class, $callback);
         $this->laravel['events']->listen(MessageProcessingFailed::class, $callback);
-        $this->laravel['events']->listen(WorkerStopping::class, $callback);
+        $this->laravel['events']->listen(WorkerStopping::class, function ($event) {
+            $this->output->info('Worker has been stopped with the status code ' . $event->status);
+        });
     }
 
     /**

--- a/src/RabbitEvents/Listener/Commands/Log/Writer.php
+++ b/src/RabbitEvents/Listener/Commands/Log/Writer.php
@@ -27,9 +27,7 @@ abstract class Writer
             ListenerHandling::class => self::STATUS_PROCESSING,
             ListenerHandled::class => self::STATUS_PROCESSED,
             ListenerHandlerExceptionOccurred::class => self::STATUS_EXCEPTION,
-            ListenerHandleFailed::class => self::STATUS_FAILED,
-            MessageProcessingFailed::class => self::STATUS_FAILED,
-            WorkerStopping::class => self::STATUS_FAILED,
+            default => self::STATUS_FAILED
         };
     }
 }

--- a/src/RabbitEvents/Listener/Commands/Log/Writer.php
+++ b/src/RabbitEvents/Listener/Commands/Log/Writer.php
@@ -7,6 +7,7 @@ use RabbitEvents\Listener\Events\ListenerHandled;
 use RabbitEvents\Listener\Events\ListenerHandling;
 use RabbitEvents\Listener\Events\ListenerHandleFailed;
 use RabbitEvents\Listener\Events\MessageProcessingFailed;
+use RabbitEvents\Listener\Events\WorkerStopping;
 
 abstract class Writer
 {
@@ -15,13 +16,9 @@ abstract class Writer
     public const STATUS_EXCEPTION = 'Exception Occurred';
     public const STATUS_FAILED = 'Failed';
 
-    /**
-     * @param ListenerHandlerExceptionOccurred | ListenerHandling | ListenerHandled | ListenerHandleFailed $event
-     */
     abstract public function log($event): void;
 
     /**
-     * @param ListenerHandlerExceptionOccurred | ListenerHandling | ListenerHandled | ListenerHandleFailed $event
      * @return string
      */
     protected function getStatus($event): string
@@ -32,6 +29,7 @@ abstract class Writer
             ListenerHandlerExceptionOccurred::class => self::STATUS_EXCEPTION,
             ListenerHandleFailed::class => self::STATUS_FAILED,
             MessageProcessingFailed::class => self::STATUS_FAILED,
+            WorkerStopping::class => self::STATUS_FAILED,
         };
     }
 }

--- a/src/RabbitEvents/Listener/Worker.php
+++ b/src/RabbitEvents/Listener/Worker.php
@@ -38,24 +38,22 @@ class Worker
         if ($supportsAsyncSignals = $this->supportsAsyncSignals()) {
             $this->listenForSignals();
         }
-
         while (true) {
             try {
                 if ($message = $consumer->nextMessage(1000)) {
-                    $this->throwExceptionIfAlreadyExceedsMaxAttempts($message, $options);
-
-                    if ($supportsAsyncSignals) {
-                        $this->registerTimeoutHandler($options);
-                    }
-
                     try {
+                        $this->skipIfAlreadyExceedsMaxAttempts($message, $options);
+                        if ($supportsAsyncSignals) {
+                            $this->registerTimeoutHandler($options);
+                        }
+
                         $processor->process($message, $options);
+
+                        if ($supportsAsyncSignals) {
+                            $this->resetTimeoutHandler();
+                        }
                     } finally {
                         $consumer->acknowledge($message);
-                    }
-
-                    if ($supportsAsyncSignals) {
-                        $this->resetTimeoutHandler();
                     }
                 }
             } catch (Throwable $throwable) {
@@ -80,18 +78,14 @@ class Worker
         // We will register a signal handler for the alarm signal so that we can kill this
         // process if it is running too long because it has frozen. This uses the async
         // signals supported in recent versions of PHP to accomplish it conveniently.
-        pcntl_signal(SIGALRM, fn() => $this->kill(static::EXIT_ERROR));
+        pcntl_signal(SIGALRM, function () {
+            $this->kill(static::EXIT_ERROR);
+        });
 
         pcntl_alarm(max($options->timeout, 0));
     }
 
-
-    /**
-     * Mark the given job as failed if it has exceeded the maximum allowed attempts.
-     *
-     * This will likely be because the job previously exceeded a timeout.
-     */
-    protected function throwExceptionIfAlreadyExceedsMaxAttempts(Message $message, ProcessingOptions $options): void
+    protected function skipIfAlreadyExceedsMaxAttempts(Message $message, ProcessingOptions $options): void
     {
         if ($options->maxTries === 0 || $message->attempts() <= $options->maxTries) {
             return;
@@ -162,7 +156,7 @@ class Worker
     /**
      * Stop listening and bail out of the script.
      *
-     * @param  int  $status
+     * @param int $status
      * @return int
      */
     public function stop(int $status = 0)
@@ -198,10 +192,12 @@ class Worker
     {
         pcntl_async_signals(true);
 
-        foreach ([SIGINT, SIGTERM] as $signal) {
-            pcntl_signal($signal, function () {
-                $this->shouldQuit = true;
-            });
-        }
+        pcntl_signal(SIGINT, function () {
+            $this->kill(self::EXIT_SUCCESS);
+        });
+
+        pcntl_signal(SIGTERM, function () {
+            $this->shouldQuit = true;
+        });
     }
 }

--- a/tests/Listener/WorkerTest.php
+++ b/tests/Listener/WorkerTest.php
@@ -76,11 +76,12 @@ class WorkerTest extends TestCase
     {
         $worker = new Worker($this->exceptionHandler, $this->events);
 
-        $consumer = m::mock(Consumer::class)->makePartial();
+        $consumer = m::mock(Consumer::class);
         $consumer->shouldReceive('nextMessage')
             ->andReturn(m::mock(Message::class));
+        $consumer->shouldReceive('acknowledge')->once();
 
-        $status = $worker->work(m::mock(Processor::class), $consumer, $this->options(['memory' => 0]));
+        $status = $worker->work(m::spy(Processor::class), $consumer, $this->options(['memory' => 0]));
 
         self::assertEquals(Worker::EXIT_MEMORY_LIMIT, $status);
         $this->events->shouldHaveReceived()->dispatch(m::type(WorkerStopping::class))->once();
@@ -141,17 +142,41 @@ class WorkerTest extends TestCase
         $consumer->shouldReceive()
             ->nextMessage(1000)
             ->andReturn($message);
+        $consumer->shouldReceive('acknowledge')->once();
 
-        $processor = m::mock(Processor::class);
-        $processor->shouldNotReceive('process');
+        $processor = m::spy(Processor::class);
 
         $worker = new Worker($this->exceptionHandler, $this->events);
         $worker->shouldQuit = true; //one tick
 
         $worker->work($processor, $consumer, $this->options(['maxTries' => 2]));
 
-        $this->exceptionHandler->shouldHaveReceived()->report(m::type(MaxAttemptsExceededException::class));
+        $processor->shouldNotHaveReceived('process');
+
         $this->events->shouldHaveReceived()->dispatch(m::type(MessageProcessingFailed::class))->once();
+    }
+
+    public function testExitIfTimedOut()
+    {
+        $consumer = m::mock(Consumer::class);
+        $consumer->shouldReceive('nextMessage')
+            ->andReturn(m::mock(Message::class));
+
+        $consumer->shouldReceive('acknowledge')->once();
+
+        $processor = m::mock(Processor::class);
+        $processor->shouldReceive('process')
+            ->andReturnUsing(function () {
+                sleep(2);
+
+                return true;
+            });
+
+        $worker = new TestWorker($this->exceptionHandler, $this->events);
+        $worker->shouldQuit = true;
+        $worker->work($processor, $consumer, $this->options(['timeout' => 1]));
+
+        self::assertEquals(Worker::EXIT_ERROR, $worker->exitStatus);
     }
 
     protected function options(array $overrides = []): ProcessingOptions
@@ -164,5 +189,16 @@ class WorkerTest extends TestCase
 
         return $options;
 
+    }
+}
+
+
+class TestWorker extends Worker
+{
+    public $exitStatus;
+
+    public function kill($status = 0)
+    {
+        $this->exitStatus = $status;
     }
 }

--- a/tests/Listener/WorkerTest.php
+++ b/tests/Listener/WorkerTest.php
@@ -162,7 +162,7 @@ class WorkerTest extends TestCase
         $consumer->shouldReceive('nextMessage')
             ->andReturn(m::mock(Message::class));
 
-        $consumer->shouldReceive('acknowledge')->once();
+        $consumer->shouldReceive('acknowledge')->twice(); //The second is because of $shouldQuite === true
 
         $processor = m::mock(Processor::class);
         $processor->shouldReceive('process')


### PR DESCRIPTION
Now the `--timeout` option works as expected. This PR fixes problem when a message wasn't acknowledged if worker was timed out. Also it writes the message to console.