### PR TITLE
Add `—stop-when-empty` option to listener to gracefully stop the listener if no message has been retrieved.

### DIFF
--- a/src/RabbitEvents/Listener/Commands/ListenCommand.php
+++ b/src/RabbitEvents/Listener/Commands/ListenCommand.php
@@ -39,7 +39,8 @@ class ListenCommand extends Command
                             {--timeout=60 : The number of seconds a massage could be handled}
                             {--tries=1 : Number of times to attempt to handle a Message before logging it failed}
                             {--sleep=5 : Sleep time in seconds before handling failed message next time}
-                            {--quiet: No console output}';
+                            {--quiet: No console output}
+                            {--stop-when-empty: Stop when no message has been retrieved}';
 
     /**
      * The console command description.
@@ -92,7 +93,8 @@ class ListenCommand extends Command
             (int) $this->option('memory'),
             (int) $this->option('tries'),
             (int) $this->option('timeout'),
-            (int) $this->option('sleep')
+            (int) $this->option('sleep'),
+            (bool) $this->option('stop-when-empty')
         );
     }
 

--- a/src/RabbitEvents/Listener/Message/ProcessingOptions.php
+++ b/src/RabbitEvents/Listener/Message/ProcessingOptions.php
@@ -12,7 +12,8 @@ class ProcessingOptions
         public int $memory = 128,
         public int $maxTries = 0,
         public int $timeout = 60,
-        public int $sleep = 5
+        public int $sleep = 5,
+        public bool $stopIfEmpty = false
     ) {
     }
 }


### PR DESCRIPTION
Hey.

I am running this in production inside a kubernetes cluster. And I have a situation where sometimes the connection randomly closes. So in order to prevent this i have implemented the `--stop-when-empty` option similar to the Laravel queue worker. 

So if the timeout runs out and a message hasn't been fetched within that time the worker will kill itself. And then i would be able to restart it using kubernetes `restartPolicy` attribute.

