### PR TITLE
Allow configuring the default log channel for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ return [
     'logging' => [
         'enabled' => env('RABBITEVENTS_LOG_ENABLED', false),
         'level' => env('RABBITEVENTS_LOG_LEVEL', 'info'),
+        'channel' => env('RABBITEVENTS_LOG_CHANNEL'),
     ],
 ];
 ```

--- a/src/RabbitEvents/Foundation/config/rabbitevents.php
+++ b/src/RabbitEvents/Foundation/config/rabbitevents.php
@@ -50,5 +50,6 @@ return [
     'logging' => [
         'enabled' => env('RABBITEVENTS_LOG_ENABLED', false),
         'level' => env('RABBITEVENTS_LOG_LEVEL', 'info'),
+        'channel' => env('RABBITEVENTS_LOG_CHANNEL')
     ],
 ];

--- a/src/RabbitEvents/Listener/Commands/Log/General.php
+++ b/src/RabbitEvents/Listener/Commands/Log/General.php
@@ -9,7 +9,7 @@ use RabbitEvents\Listener\Message\Handler;
 
 class General extends Writer
 {
-    public function __construct(protected Container $app)
+    public function __construct(protected Container $app, protected string $defaultLogLevel = 'info', protected ?string $channel = null)
     {
     }
 
@@ -23,9 +23,9 @@ class General extends Writer
         $this->write($event->handler, $status);
     }
 
-    protected function write(Handler $handler, $status): void
+    protected function write(Handler $handler, string $status): void
     {
-        $this->app['log']->log(
+        $this->app['log']->channel($this->channel)->log(
             $this->getLogLevel($status),
             sprintf('Handler "%s" %s', $handler->getName(), $status),
             [
@@ -39,14 +39,12 @@ class General extends Writer
         );
     }
 
-    protected function getLogLevel($status): string
+    protected function getLogLevel(string $status): string
     {
-        if (in_array($status, [static::STATUS_EXCEPTION, $status == static::STATUS_FAILED])) {
+        if (in_array($status, [static::STATUS_EXCEPTION, static::STATUS_FAILED])) {
             return 'error';
         }
 
-        $connection = $this->app['config']->get('rabbitevents.default', 'rabbitmq');
-
-        return $this->app['config']->get("rabbitevents.connections.$connection.logging.level", 'info');
+        return $this->defaultLogLevel;
     }
 }

--- a/src/RabbitEvents/Listener/README.md
+++ b/src/RabbitEvents/Listener/README.md
@@ -215,3 +215,5 @@ The suprvisor configuration is similar to [Laravel Queue](https://laravel.com/do
 The package provides 2 ways to see what happens to your listener. By default, it writes `processing`, `processed`, and `failed` messages to `/php/stdout`. The message includes service, event, and listener name. If you want to turn this feature off, just run listener with the `--quiet` option.
 
 The package also supports your application logger. To use it set config value `rabbitevents.logging.enabled` to `true` and choose log level.
+
+When choosing to use the application logger you may configure the package's logging channel using the config value `rabbitevents.logging.channel` by default it will use the value from `logging.default`.


### PR DESCRIPTION
Hey.

This is a very simple request which allows us to specify the logging channel for the listen command.

Instead of relaying on the default logging channel i would like it to only log to one specific channel that is different from the application itself