### PR TITLE
#123: Fix long queue name when a message released

### DIFF
--- a/src/RabbitEvents/Foundation/Support/EnqueueOptions.php
+++ b/src/RabbitEvents/Foundation/Support/EnqueueOptions.php
@@ -19,7 +19,7 @@ class EnqueueOptions implements QueueNameInterface
     {
         $name = $this->applicationName . ':' . implode(',', $this->events);
 
-        if (mb_strlen($name, 'ASCII') > 255) {
+        if (mb_strlen($name, 'ASCII') > 200) {
             $name = $this->applicationName . ':' . md5($name);
         }
 

--- a/src/RabbitEvents/Listener/Message/Handler.php
+++ b/src/RabbitEvents/Listener/Message/Handler.php
@@ -6,7 +6,6 @@ namespace RabbitEvents\Listener\Message;
 
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Arr;
-use RabbitEvents\Foundation\Context;
 use RabbitEvents\Foundation\Contracts\DelaysDelivery;
 use RabbitEvents\Foundation\Contracts\Transport;
 use RabbitEvents\Foundation\Message;

--- a/tests/Foundation/Support/EnqueueOptionsTest.php
+++ b/tests/Foundation/Support/EnqueueOptionsTest.php
@@ -26,6 +26,6 @@ class EnqueueOptionsTest extends TestCase
     {
         $enqueueOptions = new EnqueueOptions('test-app', [Str::random(300)]);
 
-        self::assertLessThan(255,strlen($enqueueOptions->resolveQueueName()) );
+        self::assertLessThan(200,strlen($enqueueOptions->resolveQueueName()) );
     }
 }


### PR DESCRIPTION
Fixes #123 

The RabbitMqDlxDelayStrategy creates a new queue using the following code: 'enqueue.'.$dest->getQueueName().'.'.$delay.'.delayed'. It seems like the queue is named using the pattern app_name:list_of_events, and if this name is between 220 and 255 characters in length, it doesn't get shortened. However, when the RabbitMqDlxDelayStrategy adds additional characters, the queue name can exceed the 255-character limit.

I have now reduced the maximum length for queue names that require shortening after reaching a certain limit.  