### PR TITLE
 Properly log MessageProcessingFailed event

### DIFF
--- a/src/RabbitEvents/Listener/Commands/ListenCommand.php
+++ b/src/RabbitEvents/Listener/Commands/ListenCommand.php
@@ -114,7 +114,9 @@ class ListenCommand extends Command
         $this->laravel['events']->listen(ListenerHandled::class, $callback);
         $this->laravel['events']->listen(ListenerHandleFailed::class, $callback);
         $this->laravel['events']->listen(ListenerHandlerExceptionOccurred::class, $callback);
-        $this->laravel['events']->listen(MessageProcessingFailed::class, $callback);
+        $this->laravel['events']->listen(MessageProcessingFailed::class, function ($event) {
+            $this->output->error('Message processing failed with the exception: ' . $event->exception->getMessage());
+        });
         $this->laravel['events']->listen(WorkerStopping::class, function ($event) {
             $this->output->info('Worker has been stopped with the status code ' . $event->status);
         });

--- a/src/RabbitEvents/Listener/Events/ListenerHandleFailed.php
+++ b/src/RabbitEvents/Listener/Events/ListenerHandleFailed.php
@@ -8,7 +8,7 @@ use RabbitEvents\Listener\Message\Handler;
 
 class ListenerHandleFailed
 {
-    public function __construct(public Handler $handler, public \Throwable $exception)
+    public function __construct(public readonly Handler $handler, public readonly \Throwable $exception)
     {
     }
 }

--- a/src/RabbitEvents/Listener/Events/ListenerHandled.php
+++ b/src/RabbitEvents/Listener/Events/ListenerHandled.php
@@ -8,7 +8,7 @@ use RabbitEvents\Listener\Message\Handler;
 
 class ListenerHandled
 {
-    public function __construct(public Handler $handler)
+    public function __construct(public readonly Handler $handler)
     {
     }
 }

--- a/src/RabbitEvents/Listener/Events/ListenerHandlerExceptionOccurred.php
+++ b/src/RabbitEvents/Listener/Events/ListenerHandlerExceptionOccurred.php
@@ -8,7 +8,7 @@ use RabbitEvents\Listener\Message\Handler;
 
 class ListenerHandlerExceptionOccurred
 {
-    public function __construct(public Handler $handler, public \Throwable $exception)
+    public function __construct(public readonly Handler $handler, public readonly \Throwable $exception)
     {
     }
 }

--- a/src/RabbitEvents/Listener/Events/ListenerHandling.php
+++ b/src/RabbitEvents/Listener/Events/ListenerHandling.php
@@ -8,7 +8,7 @@ use RabbitEvents\Listener\Message\Handler;
 
 class ListenerHandling
 {
-    public function __construct(public Handler $handler)
+    public function __construct(public readonly Handler $handler)
     {
     }
 }

--- a/src/RabbitEvents/Listener/Events/MessageProcessingFailed.php
+++ b/src/RabbitEvents/Listener/Events/MessageProcessingFailed.php
@@ -6,7 +6,7 @@ use RabbitEvents\Foundation\Message;
 
 class MessageProcessingFailed
 {
-    public function __construct(public Message $message, public \Throwable $exception)
+    public function __construct(public readonly Message $message, public readonly \Throwable $exception)
     {
     }
 }

--- a/src/RabbitEvents/Listener/Events/WorkerStopping.php
+++ b/src/RabbitEvents/Listener/Events/WorkerStopping.php
@@ -4,7 +4,7 @@ namespace RabbitEvents\Listener\Events;
 
 class WorkerStopping
 {
-    public function __construct(public int $status = 0)
+    public function __construct(public readonly int $status = 0)
     {
     }
 }

--- a/src/RabbitEvents/Listener/Exceptions/TimeoutExceededException.php
+++ b/src/RabbitEvents/Listener/Exceptions/TimeoutExceededException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitEvents\Listener\Exceptions;
+
+class TimeoutExceededException extends \RuntimeException
+{
+}

--- a/tests/Listener/WorkerTest.php
+++ b/tests/Listener/WorkerTest.php
@@ -177,6 +177,8 @@ class WorkerTest extends TestCase
         $worker->work($processor, $consumer, $this->options(['timeout' => 1]));
 
         self::assertEquals(Worker::EXIT_ERROR, $worker->exitStatus);
+
+        $this->events->shouldHaveReceived()->dispatch(m::type(MessageProcessingFailed::class))->once();
     }
 
     public function testTimeoutResetIfProcessEndedWithException()


### PR DESCRIPTION
Make some fixes and improvements:

- Properly log an output of the `MessageProcessingFailed` event.
- Refactor properties of the events: make them readonly
- Gracefully kill work by timeout: dispatch `MessageProcessingFailed` event on worker timeout