### PR TITLE
Issue #132: Use amqp-ext as a transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Once again, the RabbitEvents library helps you to publish an event and handle it
    * [rabbitevents:listen](#command-listen) - listen to an event
    * [rabbitevents:list](#command-list) - display list of registered events
 1. [Examples](/examples)
+1. [Speeding up RabbitEvents](#speeding-up-rabbitevents)
 1. [Non-standard use](#non-standard-use)
+1. [License](#license)
 
 ## Installation via Composer<a name="installation"></a>
 You may use Composer to install RabbitEvents into your Laravel project:
@@ -161,6 +163,23 @@ To get the list of all registered events please use the command `rabbitevents:li
 php artisan rabbitevents:list
 ```
 
+## Speeding up RabbitEvents<a name="speeding-up-rabbitevents"></a>
+To enhance the performance of RabbitEvents, consider installing the `php-amqp` extension along with the `enqueue/amqp-ext` package.
+By doing so, RabbitEvents will utilize the `enqueue/amqp-ext` package instead of the default `enqueue/amqp-lib` package.
+This substitution is advantageous because the C-written `php-amqp` package significantly outperforms the PHP-written `enqueue/amqp-lib` package.
+
+You can install the `php-amqp` extension using the following command:
+```bash
+pecl install amqp
+```
+or use the way you prefer. More about it can be found [here](https://pecl.php.net/package/amqp).
+
+Next, install the `enqueue/amqp-ext` package with the following command:
+```bash
+composer require enqueue/amqp-ext
+```
+No additional configuration is required.
+
 ## Non-standard use <a name="#non-standard-use"></a>
 
 If you're using only one of parts of RabbitEvents, you should know a few things:
@@ -181,3 +200,7 @@ If you're using only one of parts of RabbitEvents, you should know a few things:
 
 There'e 3 elements of an array, so 3 variables will be passed to a Listener (array, string and integer).
 If an associative array is being passed, the Dispatcher wraps this array by itself.
+
+# License <a name="license"></a>
+
+RabbitEvents is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "nuwber/rabbitevents",
   "description": "The Nuwber RabbitEvents package",
-  "keywords": ["laravel", "rabbitmq", "events", "broadcast", "publish", "pub", "sub"],
+  "keywords": ["laravel", "rabbitmq", "events", "broadcast", "publish", "pub", "sub", "amqp"],
   "type": "library",
   "license": "MIT",
   "authors": [
@@ -56,7 +56,8 @@
   },
   "suggest": {
     "ext-pcntl": "Required to use all features of the worker.",
-    "vlucas/phpdotenv": "Loads environment variables from .env to getenv(), $_ENV and $_SERVER automagically."
+    "ext-amqp": "Using this extension makes your app faster. If you're using it you need to install enqueue/amqp-ext.",
+    "enqueue/amqp-ext": "This package is necessary if you want to use `ext-amqp`."
   },
   "config": {
     "sort-packages": true

--- a/src/RabbitEvents/Foundation/Connection.php
+++ b/src/RabbitEvents/Foundation/Connection.php
@@ -88,7 +88,9 @@ class Connection
      */
     protected function factory(): AmqpConnectionFactory
     {
-        $factory = new AmqpConnectionFactory([
+        $connectionFactoryClass = $this->getConnectionFactoryClass();
+
+        $factory = new $connectionFactoryClass([
             'dsn' => $this->getConfig('dsn'),
             'host' => $this->getConfig('host', '127.0.0.1'),
             'port' => $this->getConfig('port', 5672),
@@ -115,5 +117,14 @@ class Connection
         $factory->setDelayStrategy($this->getDelayStrategy());
 
         return $factory;
+    }
+
+    private function getConnectionFactoryClass(): string
+    {
+        if (extension_loaded('amqp') && class_exists('Enqueue\AmqpExt\AmqpConnectionFactory')) {
+            return \Enqueue\AmqpExt\AmqpConnectionFactory::class;
+        } else {
+            return \Enqueue\AmqpLib\AmqpConnectionFactory::class;
+        }
     }
 }

--- a/src/RabbitEvents/Foundation/Consumer.php
+++ b/src/RabbitEvents/Foundation/Consumer.php
@@ -51,7 +51,7 @@ class Consumer
     {
         try {
             return $this->amqpConsumer->receive($timeout);
-        } catch (AMQPRuntimeException $exception) {
+        } catch (\Throwable $exception) {
             throw new ConnectionLostException($exception);
         }
     }

--- a/src/RabbitEvents/Listener/Commands/ListenCommand.php
+++ b/src/RabbitEvents/Listener/Commands/ListenCommand.php
@@ -59,6 +59,8 @@ class ListenCommand extends Command
      */
     public function handle(Context $context, Worker $worker)
     {
+        $this->checkExtLoaded();
+
         $options = $this->gatherProcessingOptions();
 
         $this->registerLogWriters($options->connectionName);
@@ -155,5 +157,13 @@ class ListenCommand extends Command
             Arr::get($config, "connections.$connection.logging.level", 'info'),
             Arr::get($config, "connections.$connection.logging.channel", null),
         ];
+    }
+
+    private function checkExtLoaded(): void
+    {
+        if (extension_loaded('amqp') && !class_exists('Enqueue\AmqpExt\AmqpConnectionFactory')) {
+            $this->info('You have ext-amqp extension installed. Require enqueue/amqp-ext package to use it.');
+            $this->info("The package can be installed via 'composer require enqueue/amqp-ext' command.");
+        }
     }
 }

--- a/src/RabbitEvents/Listener/Commands/Log/General.php
+++ b/src/RabbitEvents/Listener/Commands/Log/General.php
@@ -9,8 +9,11 @@ use RabbitEvents\Listener\Message\Handler;
 
 class General extends Writer
 {
-    public function __construct(protected Container $app, protected string $defaultLogLevel = 'info', protected ?string $channel = null)
-    {
+    public function __construct(
+        protected Container $app,
+        protected string $defaultLogLevel = 'info',
+        protected ?string $channel = null
+    ) {
     }
 
     /**

--- a/tests/Foundation/Support/ReleaserTest.php
+++ b/tests/Foundation/Support/ReleaserTest.php
@@ -28,7 +28,8 @@ class ReleaserTest extends TestCase
 
         $this->producer = m::mock(AmqpProducer::class);
         $this->producer->shouldReceive()
-            ->send($this->queue, $amqpMessage);
+            ->send($this->queue, $amqpMessage)
+            ->once();
     }
 
     public function testDeliveryDelay()

--- a/tests/Publisher/PublisherTest.php
+++ b/tests/Publisher/PublisherTest.php
@@ -25,7 +25,8 @@ class PublisherTest extends TestCase
             ->make($event)
             ->andReturn($messageMock);
         $sender = m::mock(Transport::class);
-        $sender->shouldReceive('send');
+        $sender->shouldReceive('send')
+            ->once();
 
         $publisher = new Publisher($messageFactory, $sender);
         $publisher->publish($event);


### PR DESCRIPTION
Add ability to us amqp-ext as a transport like it was done for 8.x version.